### PR TITLE
fixing get quote profit loss numbers

### DIFF
--- a/contracthistory.css
+++ b/contracthistory.css
@@ -1,0 +1,16 @@
+/*CSS for contracthistory.html*/
+
+
+th {
+	color: #096EB6;
+	font-weight: bold;
+	align-self: center;
+
+}
+
+td {
+	line-height: 200%;
+
+
+}
+

--- a/details.html
+++ b/details.html
@@ -1,0 +1,82 @@
+<!--this is a template for what the modal box should look like-->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Net Profit or Loss Details</title>
+
+    <!-- Bootstrap -->
+    <!-- <link href="css/bootstrap.min.css" rel="stylesheet"> -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="css/index.css">
+    <link rel="stylesheet" type="text/css" href="css/getquote.css">
+    <link rel="stylesheet" type="text/css" href="css/details.css">
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="text-center">
+      <header>
+        <img src="images/intswapslogo.png" alt="IntSwaps logo" height="100" width="400">
+      </header>
+      <div class="container center">
+         <div class="row">
+            <div class="col-xs-12 col-sm-12 col-lg-12">
+              <h4 class="text-center" style="color:#096EB6;">Projected Profit or (Loss) for IntSwaps Contract</h4>
+              <h4>if LIBOR minus Swap Contract Rate is</h4>
+              <h4 id="insert_rate_change_header">%</h4>
+             
+              <br/>
+            </div>   
+          </div>
+         <div class="row">
+            <div style="display: block" class="center">
+              <table class="d-flex flex-column center"> 
+                <tr><th class="text-center col-lg-12" colspan="2"><h6>Your Quote Details</h6></th></tr>
+                <tr><th class="quote">Description</th><th class="quote" style="text-align:center">Value/ Amount</th></tr>
+                <tr><td>Notional Amount</td><td id="insert_notional_detail" style="text-align:center"></td></tr>
+                <tr><td>Month and Year of Monthly Payment Swap</td><td id="insert_month_year" style="text-align:center"></td></tr>
+                <tr><td>Your Current Interest Rate</td><td id="insert_current_rate_detail" style="text-align:center"></td></tr>
+                <tr><td>Swap From/To</td><td id="insert_swap_type_detail" style="text-align:center"></td></tr>
+                <tr><td>Escrow Amount Required</td><td id="insert_escrow_detail" style="text-align:center"></td></tr>
+                 <tr><td>Swap Contract Rate</td><td id="insert_swap_rate_detail" style="text-align:center"></td></tr>
+                 <tr><td>Service Charge</td><td style="text-align:center">$2.00</td></tr>
+                 <tr><td>LIBOR at Beginning of Maturity Month minus <br> &nbsp; &nbsp; &nbsp;Swap Contract Rate (limited to 0.0% LIBOR)</td><td id="insert_rate_change_detail" style="text-align:center"></td></tr>
+              </table>
+            </div>
+          </div>
+          <div class="row">
+            <div style="display: block" class="center">
+              <table class="d-flex flex-column center"> 
+                 <th class="details">Description</th><th class="details" style="text-align:center">Month #1<br>Amount</th><th class="details" style="text-align:center">Maturity Month<br>Before Intswap<sup>TM</sup></th><th class="details" style="text-align:right">Maturity Month<br>After Intswap<sup>TM</sup></th>
+                 <tr><td id="insert_orig_pymt_label"></td><td id="insert_orig_pymt_detail" style="text-align:center"></td></td><td id="insert_revised_orig_pymt_detail" style="text-align:center"></td><td id="insert_revised_orig_pymt_again" style="text-align:right"></td></tr>
+                 <tr><td id="insert_variable_pymt_label"></td><td>&nbsp;</td><td>&nbsp;</td><td id="insert_variable_pymt_detail" style="text-align:right"></td>
+                 <tr><td id="insert_fixed_pymt_label"></td><td>&nbsp;</td><td>&nbsp;</td><td id="insert_fixed_pymt_detail" style="text-align:right"></td> 
+                 <tr><td>Your calculated profit or (loss) before escrow limit</td><td>&nbsp;</td><td>&nbsp;</td><td id="insert_net_profit_bef_adj_detail" style="text-align:right"></td></tr>
+                 <tr><td style="font-weight: bold">Your net profit or (loss) is limited to the escrow amount</td><td>&nbsp;</td><td>&nbsp;</td><td id="insert_net_profit_after_adj_detail" style="text-align:right; font-weight: bold"></td></tr>
+                 <tr><td>Escrow refunded or applied</td><td>&nbsp;</td><td>&nbsp;</td><td id="insert_escrow_applied_detail" style="text-align:right"></td></tr>
+                 <tr><td>Your net payout at maturity (before service charge)</td><td>&nbsp;</td><td>&nbsp;</td><td id="insert_net_payout_detail" style="text-align:right"></td></tr>
+                 <tr><td>Your net interest cost overall (before service charge)</td><td id="insert_month_one_net_overall_detail" style="text-align:center"></td><td id="insert_before_swap_net_overall_detail" style="text-align:center"></td><td id="insert_net_interest_overall_detail" style="text-align:right"></td></tr>
+           
+              <tr><td colspan="4" id="insert_payout_message"></td></tr> 
+            </table>
+            </div>
+          </div> 
+        </div>
+          <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/web3.min.js"></script>
+    <script src="js/details.js"></script>
+ </body>
+</html>

--- a/getquote.html
+++ b/getquote.html
@@ -1,0 +1,264 @@
+
+<!-- This will be our Create an Intswap Contract Page -->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+    <title>Get a Quote</title>
+
+    <!-- Bootstrap -->
+    <!-- <link href="css/bootstrap.min.css" rel="stylesheet"> -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="css/index.css">
+    <link rel="stylesheet" type="text/css" href="css/getquote.css">
+
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+  </head>
+  <body>
+    <div class="text-center">
+      <header>
+        <img src="images/intswapslogo.png" alt="IntSwaps logo" height="100" width="400" class="justify-content-center">
+      </header>
+      <nav>
+          <a class="btn btn-primary" href="index.html">Home</a>
+          <a class="btn btn-primary" role="button" href="#">Get a Quote</a>
+          <a class="btn btn-primary" href="browseoffers.html">Browse Offers</a>
+          <a class="btn btn-primary" href="contracthistory.html">Contract History</a>
+          <a class="btn btn-primary" href="mint_intswap.html">Mint IntSwap</a>
+          <!-- <a class="btn btn-primary" href="withdraw.html">Withdraw</a> -->
+          <a class="btn btn-primary" href="cal_payout.html">Calculate Payout</a>
+      <a class="btn btn-primary" href="withdraw_ether.html">Withdraw</a>
+          <a class="btn btn-primary" href="faq.html">FAQ</a>
+          <a class="btn btn-primary" href="about.html">About Us</a>
+      </nav>
+    </div>
+
+    <div class="container" >
+<!--had to put whole page inside a div so that reset button at bottom would work on top section step_one_input-->
+      <form id="whole_page" class="d-flex flex-column justify-content-center">
+      <div class="container" >
+         <div class="row">
+            <div class="center" width="700px">
+              <h2 class="text-center">Get an IntSwap Quote</h2>
+              <br/>
+            </div>
+         </div>
+      </div>
+      <div class="container w-50">
+        <div class="row">
+          <div id="step_one_input" class="center">
+          <label for="notional_amount">Notional amount of loan principal that IntSwap<sup>TM</sup> would apply to:</label>
+
+          <input id="notional_amount" type="number" name="notional_amount" placeholder="Amount in thousands that you want to swap interest on...">
+
+          <label for=maturity_month style="color:#096EB6;">Select month and year for the month that you would like to swap:</label>
+            <div class="d-flex flex-row justify-content-center">
+              <select id="maturity_month" type="number">
+                <option value="01">January</option>
+                <option value="02">February</option>
+                <option value="03">March</option>
+                <option value="04">April</option>
+                <option value="05">May</option>
+                <option value="06">June</option>
+                <option value="07">July</option>
+                <option value="08">August</option>
+                <option value="09">September</option>
+                <option value="10">October</option>
+                <option value="11">November</option>
+                <option value="12">December</option>
+              </select>
+              <select id="maturity_year" type="number">
+                <option value="2019">2019</option>
+                <option value="2020">2020</option>
+                <option value="2021">2021</option>
+                <option value="2022">2022</option>
+                <option value="2023">2023</option>
+                <option value="2024">2024</option>
+                <option value="2025">2025</option>
+                <option value="2026">2026</option>
+                <option value="2027">2027</option>
+                <option value="2028">2028</option>
+                <option value="2029">2029</option>
+                <option value="2030">2030</option>
+                <option value="2031">2031</option>
+                <option value="2032">2032</option>
+              </select>
+            </div>
+          <label for="current_annual_rate">What annual % rate of interest do you currently pay (e.g. 4.75)?</label>
+          <input id="current_annual_rate" type="number" step=".001" name="current_annual_rate" placeholder="%">
+          <label for="swap_out_of_rate_type">What rate type do you want to swap out of?</label>
+
+          <select id="swap_out_of_rate_type" type="number">
+            <option>Select</option>
+            <option value="1">From Fixed into Variable</option>
+            <option value="2">From Variable into Fixed</option>
+          </select>
+
+          <br/>
+          <button type="button" class="btn btn-primary center" id="getQuote" style="width: auto">Get a Quote</button>
+
+          </div>
+        </div>
+      </div>
+      <div class="container w-50">
+          <div class="row">
+            <div id="step_two_display_quote" style="display: none">
+              <table class="d-flex flex-column center">
+                <thead>
+                  <caption class="text-center">Your Quote Details</caption>
+                  <th class="quote">Description</th><th class="quote">Amount/Value</th>
+                </thead>
+                <tbody>
+                  <tr><td class="quote_label">Notional Amount</td><td id="insert_notional_amount" class="quote">$</td></tr>
+                  <tr><td class="quote_label">Maturity Month/Year</td><td id="insert_month_year" class="quote"></td></tr>
+                  <tr><td class="quote_label">Your Current %</td><td id="insert_current_annual_rate" class="quote">%</td></tr>
+                  <tr><td class="quote_label">Swap From/To</td><td id="insert_swap_out_of_rate_type" class="quote"></td></tr>
+                  <tr><td class="quote_label">Escrow Amount</td><td id="insert_escrow_amount" class="quote"></td></tr>
+                  <tr><td class="quote_label">Swap Contract %</td><td id="insert_swap_rate" class="quote"></td></tr>
+                  <tr><td class="quote_label">Service charge</td><td class="quote">$2.00</td></tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+            <br>
+          <div class="row">
+            <div id="step_three_profit_loss_table" style="display: none">
+            <table class="d-flex flex-column">
+              <thead>
+                <h6>Your profit or (loss) would be these amounts (excluding service charges) if LIBOR at the beginning of the maturity month differs from the Swap Contract Rate: </h6>
+
+                <th class="profit">Difference<br>LIBOR vs Swap Rate</th><th class="profit">Net profit<br>or (loss)</th><th class="profit" style="text-align: left">Link to Details</th>
+              </thead>
+              <tbody>
+       <!-- take out next line after test querystring method of passing variables:
+                <tr><td>-3.0%</td><td id="insert_minus_three_result" class="profit"></td><td> <a class="btn btn-sm" id="minus_three"
+                  href="/detailtemplate.html?notional=100000.50&swaprate=2.88&currentrate=4.00&swaptype=1&escrow=200.00&ratechange=-3.00" target="_blank">See details</a></td></tr> -->
+
+
+   <!--style="width: auto" not working on anchor btn-->
+                <tr><td>-3.0%</td><td id="insert_minus_three_result" class="profit"></td><td><a class="btn btn-sm details" id="minus_three"href="#">See details</a></td></tr>
+                <tr><td>-2.0%</td><td id="insert_minus_two_result" class="profit"></td><td><a class="btn btn-sm details" id="minus_two" href="#">See details</a></td></tr>
+                <tr><td>-1.0%</td><td id="insert_minus_one_result" class="profit"></td><td><a class="btn btn-sm details" id="minus_one" href="#">See details</a></td></tr>
+                <tr><td>&nbsp;&nbsp;0.0%</td><td id="insert_zero_change_result" class="profit"></td><td><a  class="btn btn-sm details" id="zero_change" href="#" >See details</a></td></tr>
+                <tr><td>+1.0%</td><td id="insert_plus_one_result" class="profit"></td><td><a class="btn btn-sm details" id="plus_one" href="#">See details</a></td></tr>
+                <tr><td>+2.0%</td><td id="insert_plus_two_result" class="profit"></td><td><a class="btn btn-sm details" id="plus_two" href="#">See details</a></td></tr>
+                <tr><td>+3.0%</td><td id="insert_plus_three_result" class="profit"></td><td><a class="btn btn-sm details" id="plus_three" href="#">See details</a></td></tr>
+
+              </tbody>
+            </table>
+
+          </div>
+              <!-- end of step-three-profit-loss-table div-->
+
+
+         <div class="row">
+          <p id="step_four_display_risks" style="display: none">
+              Please acknowledge that you understand and agree to the following:<br/>
+              1. The interest rate swap may not match the exact amount of interest on my own mortgage.<br/>
+              2. The variable index rate on my own mortgage may differ from the one-month US Dollar LIBOR index that is used for the IntSwaps variable rate.<br/>
+              3. I may lose all of my escrow if the change in interest rates is unfavorable to me.<br/>
+              4. The US Dollar LIBOR monthly rate at the beginning of the contract maturity month that I have selected will be used to determine the payout.<br/>
+              5. Fluctuations in the value of any Ether or ERC20 token posted as escrow will not be taken into account and all calculations will be based on the original conversion rate in effect at the inception of the contract.<br/>
+              6. I realize that I still must make the payment on my own mortgage direct to the holder of my mortgage.<br/>
+              7. My profit or loss will be based on the LIBOR variable rate of interest compared to the swap contract rate.<br/>
+
+              8. All interest calculations will be based on a 360 day year and 30 day months.<br>
+              9. Negative LIBOR variable interest rates, if any, will treated as zero for IntSwap payout calculations.</p>
+
+        </div>
+      </div>
+      <div class="container w-75 center">
+         <div id="step_five_agree" style="display: none; text-align: center">
+            <form>
+              <div class="radio">
+              <label><input type="radio" name="riskAgree" value="agree" id="agree"> I understand and agree.</label><br>
+              </div>
+              <div class="radio">
+              <label><input type="radio" name="riskAgree" value="disagree" id="disagree"> I do not understand/agree.</label><br><br>
+              </div>
+            </form>
+
+            <h6>Buy an IntSwap Contract and Deposit <span id="proposer_escrow_to_deposit"></span> Escrow:</h6>
+            <label>Enter Your Address</label>
+            <input class="w-100 mb-3" id="proposal_owner_address" type="text">
+            <div class="d-flex flex-row">
+                <input type="reset" id="cancelTrade" class="btn btn-primary center btn-sm" value="Cancel and reset">
+                <button type="button" class="btn btn-primary center btn-sm" id="placeTrade" style="width: auto">Yes buy it!</button><br>
+            </div>
+
+            <br>
+            <p id="RiskAgreeMessage"> </p>
+          </div>
+      </div>
+
+      <div container>
+        <div id="step_six_confirm_trade" style="display: none; text-align:center">
+           <table class="d-flex flex-column">
+              <thead>
+               <caption class="text-center">Your IntSwaps<sup>TM</sup> Trade Confirmation</caption>
+                  <th class="quote">Description</th><th class="quote">Amount/Value</th>
+              </thead>
+              <tbody>
+
+                <tr><td>Your confirmation number</td><td id="insert_confirm_number"></td></tr>
+                <tr><td>Trade Date</td><td id="insert_today"></td></tr>
+                <tr><td>Settlement Date for Escrow to be Remitted</td><td id="insert_today_plus_two"></td></tr>
+                <tr><td>Type of Swap</td><td id="insert_swap_type_confirm"></td></tr>
+                <tr><td>Notional Amount</td><td id="insert_notional_confirm"></td></tr>
+                <tr><td>Maturity Month and Year</td><td id="insert_maturity_month_year_confirm"></td></tr>
+                <tr><td>Your Current Annual Rate</td><td id="insert_current_rate_confirm"></td></tr>
+                <tr><td>Swap Contract Rate</td><td id="insert_swap_rate_confirm"></td></tr>
+                <tr><td>IntSwaps<sup>TM</sup> service charge</td><td>$2.00</td></tr>
+                <tr><td>Escrow Amount Required in US Dollars</td><td id="insert_escrow_dollar_confirm"></td></tr>
+                <tr><td>Exchange rate US Dollars per Ether</td><td id=insert_ether_exchange_rate"></td></tr>
+                <tr><td>Escrow Amount Required in Ether</td><td id="insert_escrow_ether_confirm"></td></tr>
+                <tr><td colspan="2">Congratulations!  You have purchased an IntSwaps<sup>TM</sup> Contract! </td></tr>
+                <tr><td colspan="2">Please remit your escrow payment in Ether within 48 hours</td></tr>
+                <tr><td colspan="2">to the following contract address (QR code provided)</td></tr>
+                <tr><td colspan="2" id="insert_contract_address_confirm" class="text-center">0xeba6f62f4f7bef9692ecf36cfe3eadf29fd2bed9b</td></tr>
+        <!-- take this next line out since we are not using QR codes
+                <tr><td colspan="2"><img alt="QR-code-contract-address" src="/images/QR-code-contract-address.png" class="center" height="100px" width="100px"></td> -->
+              </tbody>
+
+            </table>
+
+        </div>
+      </div>
+
+      </form>
+    <!--//end of whole page form so that reset input works-->
+    </div>
+
+
+
+
+  <div>
+    <footer>
+      <br>
+      <p>&copy IntSwaps<sup>TM</sup> LLC 2019.  All rights reserved.
+
+      </p>
+    </footer>
+  </div>
+
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="js/bootstrap.min.js"></script>
+    <script src="js/web3.min.js"></script>
+    <script src="js/truffle-contract.js"></script>
+    <script src="js/app.js"></script>
+    <script src="js/getquote.js"></script>
+ </body>
+</html>

--- a/getquote.js
+++ b/getquote.js
@@ -1,0 +1,247 @@
+//this file is for getquote.html
+
+var $notional_amount = $('#notional_amount');
+
+var $maturity_month = $('#maturity_month');
+var $maturity_year = $('#maturity_year');
+var $current_annual_rate = $('#current_annual_rate'); //needed for getdetails function
+// var maturity_month_year = maturity_month.maturity_year; //might use this variable later
+var $swap_out_of_rate_type = $('#swap_out_of_rate_type');
+
+var $swap_contract_rate = 2.880;   //hard-code this value for demo
+
+document.getElementById("getQuote").onclick = function() {getQuote()};
+
+document.getElementById("cancelTrade").onclick = function() {cancelTrade()};
+
+
+function getQuote(){
+ 
+      $("#step_one_input").hide();
+      $("#step_two_display_quote").show();
+      $("#step_three_profit_loss_table").show();
+      $("#step_four_display_risks").show();
+      $("#step_five_agree").show();
+
+      $("#step_six_confirm_trade").hide(); 
+          
+    var $notional_amount = $('#notional_amount');
+    var notional_amount = $notional_amount.val();
+    var maturity_month = $maturity_month.val();
+    var maturity_year = $maturity_year.val();
+    var current_annual_rate = $current_annual_rate.val();
+    var escrow_amount = 0.002 * notional_amount;
+    var swap_contract_rate = 2.880;   //hard-code this value for demo
+    var swap_out_of_rate_type = $swap_out_of_rate_type.val();
+    var fixed_pay_amount = notional_amount * swap_contract_rate / 1200;
+    var minus_three_pay_amount = notional_amount * (swap_contract_rate - 3.00) / 1200;
+    var minus_two_pay_amount = notional_amount * (swap_contract_rate - 2.00) / 1200;
+    var minus_one_pay_amount = notional_amount * (swap_contract_rate - 1.00) / 1200;
+    var zero_change_pay_amount = notional_amount * swap_contract_rate / 1200;
+    var plus_one_pay_amount = notional_amount * (swap_contract_rate + 1.00) / 1200;
+    var plus_two_pay_amount = notional_amount * (swap_contract_rate + 2.00) / 1200;
+    var plus_three_pay_amount = notional_amount * (swap_contract_rate + 3.00) / 1200;
+ //   var month_year =  $maturity_month.val() + "/" + maturity_year.val();
+//display quote in this section
+    document.getElementById("insert_notional_amount").innerHTML = "$" + $notional_amount.val();
+    document.getElementById("insert_month_year").innerHTML = $maturity_month.val() + "/" + $maturity_year.val();
+    document.getElementById("insert_current_annual_rate").innerHTML = $current_annual_rate.val() + "%";
+
+     if (swap_out_of_rate_type == "1" ) {
+      document.getElementById("insert_swap_out_of_rate_type").innerHTML = "From Fixed to Variable";
+    }
+    else if  (swap_out_of_rate_type == "2" ) {
+      document.getElementById("insert_swap_out_of_rate_type").innerHTML = "From Variable to Fixed";
+    }
+    else {
+      console.log("swaptype undefined for quote details");
+    }
+//correction below because we want to display words on html to describe swap type
+//    document.getElementById("insert_swap_out_of_rate_type").innerHTML = $swap_out_of_rate_type.val();
+     document.getElementById("insert_escrow_amount").innerHTML = "$" + escrow_amount.toFixed(2);
+    //this one works for swap rate--do not edit
+    document.getElementById("insert_swap_rate").innerHTML = swap_contract_rate + "%";
+     
+    // test for variable to fixed = swap type 2
+    if (swap_out_of_rate_type == "2"){
+      var minus_three_result = minus_three_pay_amount - fixed_pay_amount;
+      var minus_two_result = minus_two_pay_amount - fixed_pay_amount;
+
+      var minus_one_result = minus_one_pay_amount - fixed_pay_amount;
+      var zero_change_result = 0;
+      var plus_one_result = plus_one_pay_amount - fixed_pay_amount;
+      var plus_two_result = plus_two_pay_amount - fixed_pay_amount;
+      var plus_three_result = plus_three_pay_amount - fixed_pay_amount;
+      var limit_minus_three_result = minus_three_result;
+      var limit_plus_three_result = plus_three_result;
+
+        if (minus_three_result < (escrow_amount * -1) ) {
+          limit_minus_three_result = (escrow_amount * -1);
+        };
+        if (plus_three_result > escrow_amount) {
+          limit_plus_three_result = escrow_amount;
+        };
+
+
+      document.getElementById("insert_minus_three_result").innerHTML = "$" + limit_minus_three_result.toFixed(2);
+      document.getElementById("insert_minus_two_result").innerHTML = "&nbsp;" + minus_two_result.toFixed(2);
+
+      document.getElementById("insert_minus_one_result").innerHTML = minus_one_result.toFixed(2);
+      document.getElementById("insert_zero_change_result").innerHTML = zero_change_result.toFixed(2);
+      document.getElementById("insert_plus_one_result").innerHTML = plus_one_result.toFixed(2);
+      document.getElementById("insert_plus_two_result").innerHTML = plus_two_result.toFixed(2);
+      document.getElementById("insert_plus_three_result").innerHTML = limit_plus_three_result.toFixed(2);
+    
+    };
+   
+
+    //test for fixed to variable = swap type 1
+    if (swap_out_of_rate_type == "1"){
+
+    //   produces all NaN results if use .valueOf()  
+      var minus_three_result = fixed_pay_amount - minus_three_pay_amount;
+      var $minus_two_result = fixed_pay_amount - minus_two_pay_amount;
+      var minus_one_result = fixed_pay_amount - minus_one_pay_amount;
+      var zero_change_result = 0;
+      var plus_one_result = fixed_pay_amount - plus_one_pay_amount;
+      var plus_two_result = fixed_pay_amount - plus_two_pay_amount;
+      var plus_three_result = fixed_pay_amount - plus_three_pay_amount;
+      var limit_minus_three_result = minus_three_result;
+      var limit_plus_three_result = plus_three_result;
+ 
+       if (minus_three_result > escrow_amount ){
+          limit_minus_three_result = escrow_amount;
+        };
+      
+        if (plus_three_result < (escrow_amount * -1) ){
+          limit_plus_three_result = (escrow_amount * -1);
+        };
+
+      document.getElementById("insert_minus_three_result").innerHTML = limit_minus_three_result.toFixed(2);
+      document.getElementById("insert_minus_two_result").innerHTML = $minus_two_result.toFixed(2);
+      document.getElementById("insert_minus_one_result").innerHTML = minus_one_result.toFixed(2);
+      document.getElementById("insert_zero_change_result").innerHTML = zero_change_result.toFixed(2);
+      document.getElementById("insert_plus_one_result").innerHTML = plus_one_result.toFixed(2);
+      document.getElementById("insert_plus_two_result").innerHTML = plus_two_result.toFixed(2);
+      document.getElementById("insert_plus_three_result").innerHTML = limit_plus_three_result.toFixed(2);
+    
+    }
+
+   
+      var detailurl = "/details.html?notional=";
+      var matmonth = "&matmonth=";
+      var matyear = "&matyear=";
+      var swapratequery = "&swaprate=";
+      var currentratequery = "&currentrate=";
+      var swaptypequery = "&swaptype=";
+      var escrowquery = "&escrow=";
+      var ratechangequery = "&ratechange="
+     
+      var getHrefFront = detailurl.concat(notional_amount).concat(matmonth).concat(maturity_month).concat(matyear).concat(maturity_year).concat(swapratequery).concat(swap_contract_rate).concat(currentratequery).concat(current_annual_rate).concat(swaptypequery).concat(swap_out_of_rate_type).concat(escrowquery).concat(escrow_amount).concat(ratechangequery);
+
+      var minus_three_change = "-3"
+      var minus_two_change = "-2";
+      var minus_one_change = "-1"
+      var zero_change = "0";
+      var plus_one_change = "1";
+      var plus_two_change = "2";
+      var plus_three_change = "3";
+
+      var getMinusThreeHref = getHrefFront.concat(minus_three_change);
+      var getMinusTwoHref = getHrefFront.concat(minus_two_change);
+      var getMinusOneHref = getHrefFront.concat(minus_one_change);
+      var getZeroChangeHref = getHrefFront.concat(zero_change);
+      var getPlusOneHref = getHrefFront.concat(plus_one_change);
+      var getPlusTwoHref = getHrefFront.concat(plus_two_change);
+      var getPlusThreeHref = getHrefFront.concat(plus_three_change);
+
+      document.getElementById("minus_three").target = "_blank";
+      document.getElementById("minus_three").href = getMinusThreeHref;
+      document.getElementById("minus_two").target = "_blank";
+      document.getElementById("minus_two").href = getMinusTwoHref;
+      document.getElementById("minus_one").target = "_blank";
+      document.getElementById("minus_one").href = getMinusOneHref;  
+      document.getElementById("zero_change").target = "_blank";
+      document.getElementById("zero_change").href = getZeroChangeHref;
+      document.getElementById("plus_one").target = "_blank";
+      document.getElementById("plus_one").href = getPlusOneHref;  
+      document.getElementById("plus_two").target = "_blank";
+      document.getElementById("plus_two").href = getPlusTwoHref;  
+      document.getElementById("plus_three").target = "_blank";
+      document.getElementById("plus_three").href = getPlusThreeHref; 
+      
+
+
+  }; //end of getQuote function
+
+
+
+
+function cancelTrade(){
+         
+      $("#step_one_input").show();
+      $("#step_two_display_quote").hide();
+      $("#step_three_profit_loss_table").hide();
+      $("#step_four_display_risks").hide();
+      $("#step_five_agree").hide(); 
+      $("#step_six_confirm_trade").hide(); 
+   
+
+  } //end of cancelTrade function
+
+// see app.js for function placeTrade() that will then 
+// trigger function confirmTrade() below
+
+function confirmTrade(){
+
+    $("#step_one_input").hide();
+    $("#step_two_display_quote").hide();
+    $("#step_three_profit_loss_table").hide();
+    $("#step_four_display_risks").hide();
+    $("#step_five_agree").hide();   
+    $("#step_six_confirm_trade").show(); 
+
+    var current_annual_rate = $current_annual_rate.val();
+    var notional_amount = $notional_amount.val();
+    var escrow_amount = 0.002 * notional_amount;
+    var swap_contract_rate = 2.880;   //hard-code this value for demo
+    var confirm_number = "20190117-00001" //hard code confirm number for demo
+   //   var today = 
+   //   var today_plus_two = 
+    var swap_out_of_rate_type = $swap_out_of_rate_type.val();
+    var ether_exchange_rate = 159.11;
+    var escrow_ether_confirm = escrow_amount * ether_exchange_rate;
+    var today = new Date();
+    var today_plus_two = today.setDate(today.getDate() + 2);
+   
+    //hard code this for now until bind event to placeTrade function to get actual new contract address
+    var contract_address_confirm = "0xeba6f62f4f7bef9692ecf36cfe3eadf29fd2bed9b";  
+    // generated QR code for above address and linked direct from image to step_six_confirm_trade section for demo
+
+    document.getElementById("insert_confirm_number").innerHTML = confirm_number;
+    document.getElementById("insert_today").innerHTML = today;
+    document.getElementById("insert_today_plus_two").innerHTML = today_plus_two;
+
+    if ($swaptype == "1" ) {
+      document.getElementById("insert_swap_type_confirm").innerHTML = "From Fixed to Variable";
+    }
+    else if  ($swaptype == "2" ) {
+      document.getElementById("insert_swap_type_confirm").innerHTML = "From Variable to Fixed";
+    }
+    else {
+      console.log("swaptype undefined for trade confirmation");
+    }
+
+    document.getElementById("insert_notional_confirm").innerHTML = notional_amount;
+    document.getElementById("insert_maturity_month_year_confirm").innerHTML = $maturity_month + "/" + maturity_year;
+    document.getElementById("insert_current_rate_confirm").innerHTML = current_annual_rate;
+    document.getElementById("insert_swap_rate_confirm").innerHTML = swap_contract_rate;
+    document.getElementById("insert_escrow_dollar_confirm").innerHTML = escrow_amount;
+    document.getElementById("insert_ether_exchange_rate").innerHTML = ether_exchange_rate;
+    document.getElementById("insert_escrow_ether_confirm").innerHTML = escrow_ether_confirm;
+//    hard code contract address into html until placeTrade function is finished with solidity 
+//    document.getElementById("insert_contract_address_confirm").innerHTML = contract_address_confirm;
+
+
+}  //end of confirmTrade function
+


### PR DESCRIPTION
fixed getquote.html to agree to getdetails for each interest rate change scenario.  Fixed display of swap type in words not number.
added contracthistory.css for styling of table rows on contracthistory.html for more space between rows
added bold font to important line description on details.html
Avanika just needs to add line to contracthistory.html to link to contracthistory.css to fix line spacing.